### PR TITLE
Task Prep: AST Builder for ANTLR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>
+		<antlr4.plugin.version>4.7</antlr4.plugin.version>
+		<antlr4.version>4.7</antlr4.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -52,6 +54,11 @@
 			<version>3.10.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.antlr</groupId>
+			<artifactId>antlr4-runtime</artifactId>
+			<version>${antlr4.version}</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -81,6 +88,22 @@
 						<phase>prepare-package</phase>
 						<goals>
 							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4-maven-plugin</artifactId>
+				<version>${antlr4.plugin.version}</version>
+				<configuration>
+					<listener>false</listener>
+					<visitor>true</visitor>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>antlr4</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/src/main/antlr4/de/dhbw/mh/slang/antlr/Slang.g4
+++ b/src/main/antlr4/de/dhbw/mh/slang/antlr/Slang.g4
@@ -1,15 +1,74 @@
 grammar Slang;
 
+logicalOrExpression
+  : logicalAndExpression ( LOR logicalAndExpression )*
+  ;
+
+logicalAndExpression
+  : equalityExpression ( LAND equalityExpression )*
+  ;
+
+equalityExpression
+  : relationalExpression (( EQ | NE ) relationalExpression )*
+  ;
+
+relationalExpression
+  : additiveExpression (( LT | GT | LE | GE ) additiveExpression )*
+  ;
+
+additiveExpression
+  : multiplicativeExpression (( PLUS | MINUS ) multiplicativeExpression )*
+  ;
+
+multiplicativeExpression
+  : signedTerm (( MUL | DIV | MOD ) signedTerm )*
+  ;
+
+signedTerm
+  : ( PLUS | MINUS )? exponentiation
+  ;
+
 exponentiation
-  : atomicExpression '**' exponentiation
-  | atomicExpression ;
+  : atomicExpression POW exponentiation
+  | atomicExpression
+  ;
 
 atomicExpression
   : IDENTIFIER
-  | NUMERIC_LITERAL ;
+  | NUMERIC_LITERAL
+  | LPAREN logicalOrExpression RPAREN
+  ;
+
+
+LOR    : '||' ;
+LAND   : '&&' ;
+EQ     : '==' ;
+NE     : '!=' ;
+LT     : '<' ;
+GT     : '>' ;
+LE     : '<=' ;
+GE     : '>=' ;
+PLUS   : '+' ;
+MINUS  : '-' ;
+MUL    : '*' ;
+DIV    : '/' ;
+MOD    : '%' ;
+POW    : '**' ;
+LPAREN : '(' ;
+RPAREN : ')' ;
 
 IDENTIFIER
-  : [a-zA-Z][a-zA-Z0-9]* ;
+  : [a-zA-Z][a-zA-Z0-9]*
+  ;
 
 NUMERIC_LITERAL
-  : [0-9][.a-zA-Z0-9]* ;
+  : [0-9][.a-zA-Z0-9]*
+  ;
+
+WHITESPACE
+  : [\p{Zs}] -> channel(HIDDEN)
+  ;
+
+NEWLINE
+  : ('\r\n' | [\r\n]) -> channel(HIDDEN)
+  ;

--- a/src/main/antlr4/de/dhbw/mh/slang/antlr/Slang.g4
+++ b/src/main/antlr4/de/dhbw/mh/slang/antlr/Slang.g4
@@ -1,0 +1,15 @@
+grammar Slang;
+
+exponentiation
+  : atomicExpression '**' exponentiation
+  | atomicExpression ;
+
+atomicExpression
+  : IDENTIFIER
+  | NUMERIC_LITERAL ;
+
+IDENTIFIER
+  : [a-zA-Z][a-zA-Z0-9]* ;
+
+NUMERIC_LITERAL
+  : [0-9][.a-zA-Z0-9]* ;

--- a/src/main/java/de/dhbw/mh/slang/antlr/AstBuilder.java
+++ b/src/main/java/de/dhbw/mh/slang/antlr/AstBuilder.java
@@ -1,0 +1,25 @@
+package de.dhbw.mh.slang.antlr;
+
+import de.dhbw.mh.slang.antlr.SlangParser.AtomicExpressionContext;
+import de.dhbw.mh.slang.antlr.SlangParser.ExponentiationContext;
+import de.dhbw.mh.slang.ast.AstNode;
+
+public class AstBuilder extends SlangBaseVisitor<AstNode> {
+	
+	public AstBuilder( ){
+		super( );
+	}
+	
+	@Override
+	public AstNode visitExponentiation( ExponentiationContext ctx ){
+		// TODO Auto-generated method stub
+		return super.visitExponentiation( ctx );
+	}
+	
+	@Override
+	public AstNode visitAtomicExpression( AtomicExpressionContext ctx ){
+		// TODO Auto-generated method stub
+		return super.visitAtomicExpression( ctx );
+	}
+
+}

--- a/src/main/java/de/dhbw/mh/slang/antlr/AstBuilder.java
+++ b/src/main/java/de/dhbw/mh/slang/antlr/AstBuilder.java
@@ -1,7 +1,14 @@
 package de.dhbw.mh.slang.antlr;
 
+import de.dhbw.mh.slang.antlr.SlangParser.AdditiveExpressionContext;
 import de.dhbw.mh.slang.antlr.SlangParser.AtomicExpressionContext;
+import de.dhbw.mh.slang.antlr.SlangParser.EqualityExpressionContext;
 import de.dhbw.mh.slang.antlr.SlangParser.ExponentiationContext;
+import de.dhbw.mh.slang.antlr.SlangParser.LogicalAndExpressionContext;
+import de.dhbw.mh.slang.antlr.SlangParser.LogicalOrExpressionContext;
+import de.dhbw.mh.slang.antlr.SlangParser.MultiplicativeExpressionContext;
+import de.dhbw.mh.slang.antlr.SlangParser.RelationalExpressionContext;
+import de.dhbw.mh.slang.antlr.SlangParser.SignedTermContext;
 import de.dhbw.mh.slang.ast.AstNode;
 
 public class AstBuilder extends SlangBaseVisitor<AstNode> {
@@ -10,15 +17,49 @@ public class AstBuilder extends SlangBaseVisitor<AstNode> {
 		super( );
 	}
 	
+	
+	@Override
+	public AstNode visitLogicalOrExpression( LogicalOrExpressionContext ctx ){
+		return super.visitLogicalOrExpression( ctx );
+	}
+	
+	@Override
+	public AstNode visitLogicalAndExpression( LogicalAndExpressionContext ctx ){
+		return super.visitLogicalAndExpression( ctx );
+	}
+	
+	@Override
+	public AstNode visitEqualityExpression( EqualityExpressionContext ctx ){
+		return super.visitEqualityExpression( ctx );
+	}
+	
+	@Override
+	public AstNode visitRelationalExpression( RelationalExpressionContext ctx ){
+		return super.visitRelationalExpression( ctx );
+	}
+	
+	@Override
+	public AstNode visitAdditiveExpression( AdditiveExpressionContext ctx ){
+		return super.visitAdditiveExpression( ctx );
+	}
+	
+	@Override
+	public AstNode visitMultiplicativeExpression( MultiplicativeExpressionContext ctx ){
+		return super.visitMultiplicativeExpression( ctx );
+	}
+	
+	@Override
+	public AstNode visitSignedTerm( SignedTermContext ctx ){
+		return super.visitSignedTerm( ctx );
+	}
+	
 	@Override
 	public AstNode visitExponentiation( ExponentiationContext ctx ){
-		// TODO Auto-generated method stub
 		return super.visitExponentiation( ctx );
 	}
 	
 	@Override
 	public AstNode visitAtomicExpression( AtomicExpressionContext ctx ){
-		// TODO Auto-generated method stub
 		return super.visitAtomicExpression( ctx );
 	}
 

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderAdditiveExpressionTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderAdditiveExpressionTest.java
@@ -6,11 +6,13 @@ import static org.mockito.ArgumentMatchers.any;
 import java.util.stream.Stream;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
+@Disabled
 class AstBuilderAdditiveExpressionTest extends AstBuilderUtils {
 
 	private static Stream<Arguments> additiveExpressions() {

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderAdditiveExpressionTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderAdditiveExpressionTest.java
@@ -1,0 +1,41 @@
+package de.dhbw.mh.slang.antlr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.stream.Stream;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+class AstBuilderAdditiveExpressionTest extends AstBuilderUtils {
+
+	private static Stream<Arguments> additiveExpressions() {
+		return Stream.of(
+				Arguments.of( "19i8",                    "19i8" ),
+				Arguments.of( "19i8 + 23i8",             "(19i8+23i8)" ),
+				Arguments.of( "19i8 - 23i8",             "(19i8-23i8)" ),
+				Arguments.of( "53i8 + 43i8 + 37i8",      "((19i8+23i8)+37i8)" ),
+				Arguments.of( "53i8 + 43i8 - 37i8",      "((19i8+23i8)-37i8)" ),
+				Arguments.of( "53i8 - 43i8 + 37i8",      "((19i8-23i8)+37i8)" ),
+				Arguments.of( "53i8 - 43i8 - 37i8",      "((19i8-23i8)-37i8)" ),
+				Arguments.of( "53i8 + 43i8 + 2i8 + 7i8", "(((19i8+23i8)+37i8)+41i8)" ),
+				Arguments.of( "53i8 + 43i8 + 2i8 - 7i8", "(((19i8+23i8)+37i8)-41i8)" ),
+				Arguments.of( "53i8 + 43i8 - 2i8 + 7i8", "(((19i8+23i8)-37i8)+41i8)" )
+		);
+	}
+	
+	@ParameterizedTest
+	@MethodSource("additiveExpressions")
+	void createsSubtreeForAdditiveExpressions( String input, String expectedTree ){
+		ParseTree tree = parse( input ).additiveExpression( );
+		AstBuilder spy = Mockito.spy( AstBuilder.class );
+		Mockito.doReturn( L1 ).doReturn( L2 ).doReturn( L3 ).doReturn( L4 )
+				.when( spy ).visitMultiplicativeExpression( any() );
+		assertThat( spy.visit(tree).toString() ).isEqualTo( expectedTree );
+	}
+
+}

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderAtomicsTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderAtomicsTest.java
@@ -1,0 +1,35 @@
+package de.dhbw.mh.slang.antlr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.stream.Stream;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+class AstBuilderAtomicsTest extends AstBuilderUtils {
+
+	private static Stream<Arguments> atomicExpressions() {
+		return Stream.of(
+				Arguments.of( "11",   "11i8" ),
+				Arguments.of( "353",  "353i16" ),
+				Arguments.of( "37i8", "37i8" ),
+				Arguments.of( "abc",  "abc" ),
+				Arguments.of( "(19)", "19i8" )
+		);
+	}
+	
+	@ParameterizedTest
+	@MethodSource("atomicExpressions")
+	void createsSubtreeForAtomicexpression( String input, String expectedTree ){
+		ParseTree tree = parse( input ).atomicExpression( );
+		AstBuilder spy = Mockito.spy( AstBuilder.class );
+		Mockito.doReturn( L1 ).when( spy ).visitLogicalOrExpression( any() );
+		assertThat( spy.visit(tree).toString() ).isEqualTo( expectedTree );
+	}
+
+}

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderAtomicsTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderAtomicsTest.java
@@ -6,11 +6,13 @@ import static org.mockito.ArgumentMatchers.any;
 import java.util.stream.Stream;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
+@Disabled
 class AstBuilderAtomicsTest extends AstBuilderUtils {
 
 	private static Stream<Arguments> atomicExpressions() {

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderEqualityExpressionTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderEqualityExpressionTest.java
@@ -6,11 +6,13 @@ import static org.mockito.ArgumentMatchers.any;
 import java.util.stream.Stream;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
+@Disabled
 class AstBuilderEqualityExpressionTest extends AstBuilderUtils {
 
 	private static Stream<Arguments> equalityExpressions() {

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderEqualityExpressionTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderEqualityExpressionTest.java
@@ -1,0 +1,39 @@
+package de.dhbw.mh.slang.antlr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.stream.Stream;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+class AstBuilderEqualityExpressionTest extends AstBuilderUtils {
+
+	private static Stream<Arguments> equalityExpressions() {
+		return Stream.of(
+				Arguments.of( "19i8",                        "19i8" ),
+				Arguments.of( "19i8 == 23i8",                "(19i8==23i8)" ),
+				Arguments.of( "19i8 != 23i8",                "(19i8!=23i8)" ),
+				Arguments.of( "19i8 == 23i8 == 37i8",        "((19i8==23i8)==37i8)" ),
+				Arguments.of( "19i8 == 23i8 != 37i8",        "((19i8==23i8)!=37i8)" ),
+				Arguments.of( "19i8 != 23i8 == 37i8",        "((19i8!=23i8)==37i8)" ),
+				Arguments.of( "19i8 != 23i8 != 37i8",        "((19i8!=23i8)!=37i8)" ),
+				Arguments.of( "53i8 == 43i8 != 2i8 == 41i8", "(((19i8==23i8)!=37i8)==41i8)" )
+		);
+	}
+	
+	@ParameterizedTest
+	@MethodSource("equalityExpressions")
+	void createsSubtreeForEqualityExpressions( String input, String expectedTree ){
+		ParseTree tree = parse( input ).equalityExpression( );
+		AstBuilder spy = Mockito.spy( AstBuilder.class );
+		Mockito.doReturn( L1 ).doReturn( L2 ).doReturn( L3 ).doReturn( L4 )
+				.when( spy ).visitRelationalExpression( any() );
+		assertThat( spy.visit(tree).toString() ).isEqualTo( expectedTree );
+	}
+
+}

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderExponentiationTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderExponentiationTest.java
@@ -6,11 +6,13 @@ import static org.mockito.ArgumentMatchers.any;
 import java.util.stream.Stream;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
+@Disabled
 class AstBuilderExponentiationTest extends AstBuilderUtils {
 
 	private static Stream<Arguments> exponentiations() {

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderExponentiationTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderExponentiationTest.java
@@ -1,0 +1,33 @@
+package de.dhbw.mh.slang.antlr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.stream.Stream;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+class AstBuilderExponentiationTest extends AstBuilderUtils {
+
+	private static Stream<Arguments> exponentiations() {
+		return Stream.of(
+				Arguments.of( "19i8",                "19i8" ),
+				Arguments.of( "19i8 ** 23i8",        "(19i8**23i8)" ),
+				Arguments.of( "19i8 ** 23i8 ** 37i8", "(19i8**(23i8**37i8))" )
+		);
+	}
+	
+	@ParameterizedTest
+	@MethodSource("exponentiations")
+	void createsSubtreeForExponentiation( String input, String expectedTree ){
+		ParseTree tree = parse( input ).exponentiation( );
+		AstBuilder spy = Mockito.spy( AstBuilder.class );
+		Mockito.doReturn( L1 ).doReturn( L2 ).doReturn( L3 ).when( spy ).visitAtomicExpression( any() );
+		assertThat( spy.visit(tree).toString() ).isEqualTo( expectedTree );
+	}
+
+}

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderLogicalAndExpressionTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderLogicalAndExpressionTest.java
@@ -1,0 +1,35 @@
+package de.dhbw.mh.slang.antlr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.stream.Stream;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+class AstBuilderLogicalAndExpressionTest extends AstBuilderUtils {
+
+	private static Stream<Arguments> logicalAndExpressions() {
+		return Stream.of(
+				Arguments.of( "19i8",                       "19i8" ),
+				Arguments.of( "19i8 && 23i8",               "(19i8&&23i8)" ),
+				Arguments.of( "19i8 && 23i8 && 37i8",        "((19i8&&23i8)&&37i8)" ),
+				Arguments.of( "19i8 && 23i8 && 37i8 && 41i8", "(((19i8&&23i8)&&37i8)&&41i8)" )
+		);
+	}
+	
+	@ParameterizedTest
+	@MethodSource("logicalAndExpressions")
+	void createsSubtreeForLogicalAndExpressions( String input, String expectedTree ){
+		ParseTree tree = parse( input ).logicalAndExpression( );
+		AstBuilder spy = Mockito.spy( AstBuilder.class );
+		Mockito.doReturn( L1 ).doReturn( L2 ).doReturn( L3 ).doReturn( L4 )
+				.when( spy ).visitEqualityExpression( any() );
+		assertThat( spy.visit(tree).toString() ).isEqualTo( expectedTree );
+	}
+
+}

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderLogicalAndExpressionTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderLogicalAndExpressionTest.java
@@ -6,11 +6,13 @@ import static org.mockito.ArgumentMatchers.any;
 import java.util.stream.Stream;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
+@Disabled
 class AstBuilderLogicalAndExpressionTest extends AstBuilderUtils {
 
 	private static Stream<Arguments> logicalAndExpressions() {

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderLogicalOrExpressionTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderLogicalOrExpressionTest.java
@@ -6,11 +6,13 @@ import static org.mockito.ArgumentMatchers.any;
 import java.util.stream.Stream;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
+@Disabled
 class AstBuilderLogicalOrExpressionTest extends AstBuilderUtils {
 
 	private static Stream<Arguments> logicalOrExpressions() {

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderLogicalOrExpressionTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderLogicalOrExpressionTest.java
@@ -1,0 +1,35 @@
+package de.dhbw.mh.slang.antlr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.stream.Stream;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+class AstBuilderLogicalOrExpressionTest extends AstBuilderUtils {
+
+	private static Stream<Arguments> logicalOrExpressions() {
+		return Stream.of(
+				Arguments.of( "19i8",                         "19i8" ),
+				Arguments.of( "19i8 || 23i8",                 "(19i8||23i8)" ),
+				Arguments.of( "19i8 || 23i8 || 37i8",         "((19i8||23i8)||37i8)" ),
+				Arguments.of( "19i8 || 23i8 || 37i8 || 41i8", "(((19i8||23i8)||37i8)||41i8)" )
+		);
+	}
+	
+	@ParameterizedTest
+	@MethodSource("logicalOrExpressions")
+	void createsSubtreeForLogicalOrExpressions( String input, String expectedTree ){
+		ParseTree tree = parse( input ).logicalOrExpression( );
+		AstBuilder spy = Mockito.spy( AstBuilder.class );
+		Mockito.doReturn( L1 ).doReturn( L2 ).doReturn( L3 ).doReturn( L4 )
+				.when( spy ).visitLogicalAndExpression( any() );
+		assertThat( spy.visit(tree).toString() ).isEqualTo( expectedTree );
+	}
+
+}

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderMultiplicativeExpressionTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderMultiplicativeExpressionTest.java
@@ -1,0 +1,39 @@
+package de.dhbw.mh.slang.antlr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.stream.Stream;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+class AstBuilderMultiplicativeExpressionTest extends AstBuilderUtils {
+
+	private static Stream<Arguments> multiplicativeExpressions() {
+		return Stream.of(
+				Arguments.of( "19i8",                      "19i8" ),
+				Arguments.of( "19i8 * 23i8",               "(19i8*23i8)" ),
+				Arguments.of( "19i8 / 23i8",               "(19i8/23i8)" ),
+				Arguments.of( "19i8 % 23i8",               "(19i8%23i8)" ),
+				Arguments.of( "19i8 * 23i8 * 37i8",        "((19i8*23i8)*37i8)" ),
+				Arguments.of( "19i8 * 23i8 / 37i8",        "((19i8*23i8)/37i8)" ),
+				Arguments.of( "19i8 / 23i8 * 37i8",        "((19i8/23i8)*37i8)" ),
+				Arguments.of( "19i8 / 23i8 / 37i8",        "((19i8/23i8)/37i8)" ),
+				Arguments.of( "19i8 * 23i8 / 37i8 % 41i8", "(((19i8*23i8)/37i8)%41i8)" )
+		);
+	}
+	
+	@ParameterizedTest
+	@MethodSource("multiplicativeExpressions")
+	void createsSubtreeForMultiplicativeExpressions( String input, String expectedTree ){
+		ParseTree tree = parse( input ).multiplicativeExpression( );
+		AstBuilder spy = Mockito.spy( AstBuilder.class );
+		Mockito.doReturn( L1 ).doReturn( L2 ).doReturn( L3 ).doReturn( L4 ).when( spy ).visitSignedTerm( any() );
+		assertThat( spy.visit(tree).toString() ).isEqualTo( expectedTree );
+	}
+
+}

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderMultiplicativeExpressionTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderMultiplicativeExpressionTest.java
@@ -6,11 +6,13 @@ import static org.mockito.ArgumentMatchers.any;
 import java.util.stream.Stream;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
+@Disabled
 class AstBuilderMultiplicativeExpressionTest extends AstBuilderUtils {
 
 	private static Stream<Arguments> multiplicativeExpressions() {

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderRelationalExpressionTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderRelationalExpressionTest.java
@@ -6,11 +6,13 @@ import static org.mockito.ArgumentMatchers.any;
 import java.util.stream.Stream;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
+@Disabled
 class AstBuilderRelationalExpressionTest extends AstBuilderUtils {
 
 	private static Stream<Arguments> relationalExpressions() {

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderRelationalExpressionTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderRelationalExpressionTest.java
@@ -1,0 +1,41 @@
+package de.dhbw.mh.slang.antlr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.stream.Stream;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+class AstBuilderRelationalExpressionTest extends AstBuilderUtils {
+
+	private static Stream<Arguments> relationalExpressions() {
+		return Stream.of(
+				Arguments.of( "19i8",                      "19i8" ),
+				Arguments.of( "19i8 < 23i8",               "(19i8<23i8)" ),
+				Arguments.of( "19i8 > 23i8",               "(19i8>23i8)" ),
+				Arguments.of( "19i8 <= 23i8",              "(19i8<=23i8)" ),
+				Arguments.of( "19i8 >= 23i8",              "(19i8>=23i8)" ),
+				Arguments.of( "19i8 < 23i8 < 37i8",        "((19i8<23i8)<37i8)" ),
+				Arguments.of( "19i8 < 23i8 > 37i8",        "((19i8<23i8)>37i8)" ),
+				Arguments.of( "19i8 > 23i8 < 37i8",        "((19i8>23i8)<37i8)" ),
+				Arguments.of( "19i8 > 23i8 > 37i8",        "((19i8>23i8)>37i8)" ),
+				Arguments.of( "19i8 < 23i8 < 37i8 < 41i8", "(((19i8<23i8)<37i8)<41i8)" )
+		);
+	}
+	
+	@ParameterizedTest
+	@MethodSource("relationalExpressions")
+	void createsSubtreeForRelationalExpressions( String input, String expectedTree ){
+		ParseTree tree = parse( input ).relationalExpression( );
+		AstBuilder spy = Mockito.spy( AstBuilder.class );
+		Mockito.doReturn( L1 ).doReturn( L2 ).doReturn( L3 ).doReturn( L4 )
+				.when( spy ).visitAdditiveExpression( any() );
+		assertThat( spy.visit(tree).toString() ).isEqualTo( expectedTree );
+	}
+
+}

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderSignedExpressionTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderSignedExpressionTest.java
@@ -1,0 +1,33 @@
+package de.dhbw.mh.slang.antlr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.stream.Stream;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+class AstBuilderSignedExpressionTest extends AstBuilderUtils {
+
+	private static Stream<Arguments> signedExpressions() {
+		return Stream.of(
+				Arguments.of( "19i8",  "19i8" ),
+				Arguments.of( "+19i8", "+19i8" ),
+				Arguments.of( "-19i8", "-19i8" )
+		);
+	}
+	
+	@ParameterizedTest
+	@MethodSource("signedExpressions")
+	void createsSubtreeForSignedExpressions( String input, String expectedTree ){
+		ParseTree tree = parse( input ).signedTerm( );
+		AstBuilder spy = Mockito.spy( AstBuilder.class );
+		Mockito.doReturn( L1 ).when( spy ).visitExponentiation( any() );
+		assertThat( spy.visit(tree).toString() ).isEqualTo( expectedTree );
+	}
+
+}

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderSignedExpressionTest.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderSignedExpressionTest.java
@@ -6,11 +6,13 @@ import static org.mockito.ArgumentMatchers.any;
 import java.util.stream.Stream;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
+@Disabled
 class AstBuilderSignedExpressionTest extends AstBuilderUtils {
 
 	private static Stream<Arguments> signedExpressions() {

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderTestSuite.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderTestSuite.java
@@ -1,0 +1,20 @@
+package de.dhbw.mh.slang.antlr;
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({
+	AstBuilderLogicalOrExpressionTest.class,
+	AstBuilderLogicalAndExpressionTest.class,
+	AstBuilderEqualityExpressionTest.class,
+	AstBuilderRelationalExpressionTest.class,
+	AstBuilderAdditiveExpressionTest.class,
+	AstBuilderMultiplicativeExpressionTest.class,
+	AstBuilderSignedExpressionTest.class,
+	AstBuilderExponentiationTest.class,
+	AstBuilderAtomicsTest.class
+	})
+public class AstBuilderTestSuite {
+
+}

--- a/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderUtils.java
+++ b/src/test/java/de/dhbw/mh/slang/antlr/AstBuilderUtils.java
@@ -1,0 +1,25 @@
+package de.dhbw.mh.slang.antlr;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+
+import de.dhbw.mh.slang.I8;
+import de.dhbw.mh.slang.ast.AstLiteral;
+
+public class AstBuilderUtils {
+	
+	protected static final AstLiteral L1 = new AstLiteral( new I8((byte)19) );
+	protected static final AstLiteral L2 = new AstLiteral( new I8((byte)23) );
+	protected static final AstLiteral L3 = new AstLiteral( new I8((byte)37) );
+	protected static final AstLiteral L4 = new AstLiteral( new I8((byte)41) );
+	
+	protected static SlangParser parse( String input ){
+		CharStream codePointStream = CharStreams.fromString( input );
+		SlangLexer lexer = new SlangLexer( codePointStream );
+		CommonTokenStream tokenStream = new CommonTokenStream( lexer );
+		SlangParser parser = new SlangParser( tokenStream );
+		return parser;
+	}
+
+}


### PR DESCRIPTION
In the next lecture, students will be asked to work in groups to implement an AST builder for a parser generated by ANTLR. This PR lays the groundwork for that by providing

* a grammar with the same specifications as the currently implemented language,
* a class for the AST builder with dummy implementations,
* and some unit tests that are fairly distributed among the groups.

The tests are currently deactivated so that CI/CD can serve its purpose.